### PR TITLE
[IMP] export options in xml namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.2.0",
         "@testing-library/user-event": "^13.5.0",
+        "camelcase": "^6.2.0",
+        "decamelize": "^6.0.0",
         "gh-pages": "^4.0.0",
         "paper": "^0.12.15",
         "react": "^18.1.0",
@@ -5769,6 +5771,17 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decimal.js": {
@@ -19537,6 +19550,11 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "decamelize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.0.tgz",
+      "integrity": "sha512-Fv96DCsdOgB6mdGl67MT5JaTNKRzrzill5OH5s8bjYJXVlcXyPYGyPsUkWyGV5p1TXI5esYIYMMeDJL0hEIwaA=="
     },
     "decimal.js": {
       "version": "10.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",
+    "camelcase": "^6.2.0",
+    "decamelize": "^6.0.0",
     "gh-pages": "^4.0.0",
     "paper": "^0.12.15",
     "react": "^18.1.0",


### PR DESCRIPTION
This commit replaces the WATERMARK by an actual xml namespace URI, which we use to export the icon options.

These options could then be used to implement a re-import feature.