### PR TITLE
[IMP] Save/restore iconify name

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,7 @@ const App = () => {
     const [iconSpec, setIconSpec] = useState({
         version: VERSIONS[VERSIONS.length -1],
         iconPath: null,
+        iconIconifyName: null,
         color: DEFAULT_COLORS[Math.floor(Math.random()*DEFAULT_COLORS.length)],
         size: 65,
     });
@@ -44,6 +45,7 @@ const App = () => {
                     size: specs.iconSize * 100,
                     color: specs.backgroundColor,
                     iconPath: specs.iconPathData,
+                    iconNameSanitized: specs.iconIconifyName,
                 }
                 setIconSpec(iconSpec => {return {...iconSpec, ...newSpecs}})
             } else {
@@ -54,8 +56,8 @@ const App = () => {
         reader.readAsText(file);
     }, []);
 
-    const onChangeIconPicker = useCallback(iconPath => {
-        setIconSpec(iconSpec => {return {...iconSpec, iconPath}});
+    const onChangeIconPicker = useCallback(iconDetails => {
+        setIconSpec(iconSpec => {return {...iconSpec, ...iconDetails}});
     }, []);
 
     const {getRootProps} = useDropzone({
@@ -65,10 +67,11 @@ const App = () => {
     })
 
     useEffect(() => {
-        const {version, iconPath, color, size} = iconSpec;
+        const {version, iconPath, name, color, size} = iconSpec;
         setLoading(true);
         setIcon(new OdooIcons[version]({
             iconPathData: iconPath,
+            iconIconifyName: name,
             backgroundColor: color,
             iconSize: size / 100,
         }));

--- a/src/components/IconifyIconPicker.js
+++ b/src/components/IconifyIconPicker.js
@@ -11,7 +11,7 @@ import Iconify from '@iconify/iconify'
 const DEFAULT_ICON_NAME = "mdi:home";
 
 
-const IconifyIconPicker = ({name, required, placeholder, defaultValue, onChange}) => {
+const IconifyIconPicker = ({ name, required, placeholder, defaultValue, onChange }) => {
 
     const [iconName, setIconName] = useState(defaultValue || DEFAULT_ICON_NAME);
 
@@ -27,7 +27,7 @@ const IconifyIconPicker = ({name, required, placeholder, defaultValue, onChange}
             }
             const iconSVG = Iconify.renderSVG(iconNameSanitized).outerHTML;
             const iconPath = getCombinedPathFromSvg(iconSVG);
-            onChange && onChange(iconPath);
+            onChange && onChange({ iconPath: iconPath, name: iconNameSanitized });
         })();
     }, [iconName, onChange]);
 

--- a/src/icon/icon.js
+++ b/src/icon/icon.js
@@ -72,6 +72,7 @@ class AbstractIcon {
             iconSize: 1,
             iconColor: "#000000",
             iconPathData: "",
+            iconIconifyName: "",
         }
     }
     get iconPathData() {


### PR DESCRIPTION
@ivantodorovich

This is an attempt to keep the iconify name in the SVG after the changes introduced by https://github.com/ivantodorovich/odoo-icon/pull/3 (this part works) but I'm not able to restore it when dropping a file on the canvas like https://github.com/ivantodorovich/odoo-icon/pull/7

I made some tests but I don't know / understand how to reflect the changes to the `IconifyIconPicker` component, do you have some advice ?

In a final step, the purpose of this is to use the path from the dropped file as a fallback solution if no valid iconify icon is found.
